### PR TITLE
Move meteors horizontally

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -41,6 +41,10 @@ Board.prototype.changeImpactedMeteorAndObjectStatuses = function() {
     if (meteor.center.y + meteor.size.height / 2 >= this.height){
       this.changeActiveStatus(meteor);
       this.changeActiveStatus(this.players[0]);
+    }else if (meteor.center.x <= -meteor.size.width / 2 ||
+              meteor.center.x >= this.width + meteor.size.width / 2
+             ) {
+      this.changeActiveStatus(meteor);
     }
   }.bind(this));
 };

--- a/lib/meteor.js
+++ b/lib/meteor.js
@@ -4,17 +4,19 @@ function Meteor(board) {
   var randomXPosition = Math.floor(Math.random() * this.board.width);
   var randomWidth = Math.floor(Math.random() * 25) + 16;
   var randomHeight = Math.floor(Math.random() * 25) + 16;
-  var randomVelocity = Math.floor(Math.random() * 3) + 1;
+  var yVelocity = Math.floor(Math.random() * 3) + 1;
+  var xVelocity = Math.floor(Math.random() * 3) - Math.floor(Math.random() * 3);
 
   this.size = { width: randomWidth, height: randomHeight};
   this.center = { x: randomXPosition, y: 0 - (this.size.height / 2) };
-  this.velocity = { x: 0, y: randomVelocity };
+  this.velocity = { x: xVelocity, y: yVelocity };
   this.active = true;
   this.board.meteors.push(this);
 }
 
 Meteor.prototype.update = function() {
   this.center.y += this.velocity.y;
+  this.center.x += this.velocity.x;
 }
 
 module.exports = Meteor;

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -18,8 +18,8 @@ var Runner = function() {
   var gameLoop = function() {
     if(board.players.length >= 1) {
       self.update(board);
-      board.removeInActiveObjects();
       self.draw(context, gameSize, board);
+      board.removeInActiveObjects();
       requestAnimationFrame(gameLoop);
     } else {
       window.alert("Game over!");

--- a/test/board-test.js
+++ b/test/board-test.js
@@ -288,4 +288,36 @@ describe('Board', function() {
       assert.equal(board.bullets.length, 0)
     });
   });
+
+  describe('when meteor exits the screen horizontally', function() {
+    it('on the right, the board removes the meteor from the meteor array', function(){
+      let board = new Board();
+      let player = board.addPlayer();
+      let meteor = board.addMeteor();
+
+      assert.equal(board.players.length, 1)
+      assert.equal(board.meteors.length, 1)
+
+      meteor.center.x = -meteor.size.width / 2;
+
+      board.removeInActiveObjects();
+
+      assert.equal(board.meteors.length, 0)
+    });
+
+    it('on the left, the board removes the meteor from the meteor array', function(){
+      let board = new Board();
+      let player = board.addPlayer();
+      let meteor = board.addMeteor();
+
+      assert.equal(board.players.length, 1)
+      assert.equal(board.meteors.length, 1)
+
+      meteor.center.x = board.width + meteor.size.width / 2;
+
+      board.removeInActiveObjects();
+
+      assert.equal(board.meteors.length, 0)
+    });
+  });
 });

--- a/test/meteor-test.js
+++ b/test/meteor-test.js
@@ -53,15 +53,23 @@ describe('Meteor', function() {
       assert.isBelow(meteor.velocity.y, 5);
     });
 
-    it('should move straight down from its starting position', function() {
+    it('should have a random X velocity between -2 and 2', function() {
+      let meteor = new Meteor(this.board);
+      assert.isAbove(meteor.velocity.x, -3);
+      assert.isBelow(meteor.velocity.x, 3);
+    });
+
+    it('should move from its starting position', function() {
       let meteor = new Meteor(this.board);
       let originalCenterX = meteor.center.x;
       let originalCenterY = meteor.center.y;
+      let changeInX       = meteor.velocity.x;
+      let changeInY       = meteor.velocity.y;
 
       meteor.update();
 
-      assert.equal(meteor.center.x, originalCenterX);
-      assert.isAbove(meteor.center.y, originalCenterY);
+      assert.equal(meteor.center.x, originalCenterX + changeInX);
+      assert.equal(meteor.center.y, originalCenterY + changeInY);
     });
   });
 });


### PR DESCRIPTION
Changed the velocity on the x position for the meteor to be between -2 and 2, and updated changeImpactMeteorAndObjectStatuses function with updated logic for removing meteor when it exits the screen horizontally. This was done so that we do not have to iterate through the meteors a second time and potentially slow the program down to remove meteors. The code logic will need to be refactored as it violates the SRP principle. But for now it does the thing.

Next step besides refactoring will be to add the delay on bullet firing and refactoring.

Closes #27 
